### PR TITLE
fixed issue when run docker-compose for library version libffi6

### DIFF
--- a/graphite/Dockerfile
+++ b/graphite/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install Dependencies
 RUN \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends python-minimal supervisor libffi5 libcairo2 && \
+    apt-get install -y --no-install-recommends python-minimal supervisor libffi6 libcairo2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
In the new version, this error appears: 
'E: Unable to locate package libffi5'

Just Change the library's version
